### PR TITLE
scan all rows of CSV to guess file types

### DIFF
--- a/R/check_meta_indicator_dp.R
+++ b/R/check_meta_indicator_dp.R
@@ -19,11 +19,11 @@ check_meta_indicator_dp <- function(
 ) {
   indicator_dps <- meta |>
     dplyr::filter(
-      col_type == "Filter",
-      !is.na(indicator_dp),
-      indicator_dp != ""
+      .data$col_type == "Filter",
+      !is.na(.data$indicator_dp),
+      .data$indicator_dp != ""
     ) |>
-    dplyr::pull(indicator_dp)
+    dplyr::pull(.data$indicator_dp)
 
   if (length(indicator_dps) == 0) {
     test_output(

--- a/R/utils.R
+++ b/R/utils.R
@@ -184,16 +184,9 @@ read_ees_files <- function(datapath, metapath) {
     )
   }
 
-  # Meta files are so small it's fastest to read using base R
-  #             expr     min      lq     mean   median      uq     max neval
-  # dt(example_meta)   891.9   955.6  1184.28  1048.10  1321.8  2093.3    10
-  # readr(example_meta) 11232.2 11532.4 11999.88 11831.15 12604.4 12946.6  10
-  # duck(example_meta)  1241.6  1259.5  1647.03  1404.40  1690.7  2915.3   10
-  # base(example_meta)   514.8   528.3   675.26   590.30   616.3  1472.4   10
-  metafile <- read.csv(metapath)
-
   # Read in the CSV files -----------------------------------------------------
   # TODO: Add better handling for if there's issues reading the files
+
   # Lazy reading of data for speed
   datafile <- duckplyr::read_csv_duckdb(
     datapath,
@@ -202,6 +195,13 @@ read_ees_files <- function(datapath, metapath) {
     # Resorting to scanning full file for types for now
     options = list(sample_size = -1)
   )
+
+  # Issue with read.csv falling over when handed files from Azure, so using
+  # ...duckplyr as a safer reading in method
+  # Metadata is always tiny so reading fully into memory for simplicity and
+  # ...avoiding fallbacks from duckdb
+  metafile <- duckplyr::read_csv_duckdb(metapath) |>
+    dplyr::collect()
 
   list(data = datafile, meta = metafile)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -184,18 +184,24 @@ read_ees_files <- function(datapath, metapath) {
     )
   }
 
-  # Read in the CSV files -----------------------------------------------------
-  # TODO: Add better handling for if there's issues reading the files
-  # Lazy reading of data for speed
-  datafile <- duckplyr::read_csv_duckdb(datapath)
-
   # Meta files are so small it's fastest to read using base R
   #             expr     min      lq     mean   median      uq     max neval
   # dt(example_meta)   891.9   955.6  1184.28  1048.10  1321.8  2093.3    10
   # readr(example_meta) 11232.2 11532.4 11999.88 11831.15 12604.4 12946.6  10
   # duck(example_meta)  1241.6  1259.5  1647.03  1404.40  1690.7  2915.3   10
   # base(example_meta)   514.8   528.3   675.26   590.30   616.3  1472.4   10
-  metafile <- duckplyr::read_csv_duckdb(metapath)
+  metafile <- read.csv(metapath)
+
+  # Read in the CSV files -----------------------------------------------------
+  # TODO: Add better handling for if there's issues reading the files
+  # Lazy reading of data for speed
+  datafile <- duckplyr::read_csv_duckdb(
+    datapath,
+    # Tried specifying indicator cols as VARCHAR but in current duckdb version
+    # ...you can only specify one at a time
+    # Resorting to scanning full file for types for now
+    options = list(sample_size = -1)
+  )
 
   list(data = datafile, meta = metafile)
 }


### PR DESCRIPTION
## Overview of changes

Fixes #2. Forces duckdb to read the whole CSV before guessing a column type.

I wanted to do something fancier, by extracting indicators and then passing them into the options in duckdb's auto detection to force all indicators to VARCHAR, however that option only takes one column - https://duckdb.org/docs/stable/data/csv/auto_detection. So the easiest approach was to force scanning the full file. I expect a mild performance hit, but still likely a lot faster than the previous reading of CSVs in the Shiny app.

## Why are these changes being made?

We have some awkward columns that are numeric, but with occasional character symbols. This was tripping up the function trying force the likes of 'x' to a double.

Moving the metadata to use read.csv, as a) it's faster and b) we have code on the metadata file that triggers fallbacks away from duckplyr and those messages can build up in the console, so read.csv is less noisy for how we scan the metadata.

Explicitly referencing some data masking to bat away linting notes.

## Checklist

- [x] I have tested these changes locally using `shinytest2::test_app()`<!-- replace with your specific automated test command if different -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

Test with the problematic file yourself to make sure, but otherwise if the automated tests pass I'm pretty confident in these changes so not a lot of testing needed.