### PR TITLE
Removed use of ncol in order to prevent unecessary materialisation of data

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -152,6 +152,15 @@ a. Make use of the `tests/utils/copy_check_data.R` script to copy over CSVs from
 
 b. There should be a collection of unit tests and at least one example data file with an expected failure for every function
 
+## Identifying resource heavy processes
+
+We aim to do everything optimally with lazy loading of the data, however some functions may inadvertantly actualise the whole data frame. To identify these kind of instances, it can be useful to use the `prudence = "stingy"` flag when loading the data. This will cause the code to come to a halt if any significant resources are required by a process handling the lazy table.
+
+To use `"stingy"` in this way, follow these steps:
+
+- Run `screen_dfs(<data>, <meta>, prudence = "stingy")`
+- If the lazy table is materialised, an error will be thrown, if it is then identify the guilty line by running:
+  - `rlang::last_trace()`
 ## Other things to add to the package
 
 TODO: Add trello card workflow

--- a/R/precheck_col_to_rows.R
+++ b/R/precheck_col_to_rows.R
@@ -25,7 +25,7 @@ precheck_col_to_rows <- function(
   verbose = FALSE,
   stop_on_error = FALSE
 ) {
-  data_cols <- ncol(data) - 5
+  data_cols <- length(dplyr::tbl_vars(data)) - 5
   meta_rows <- nrow(meta)
 
   if (data_cols < meta_rows) {

--- a/R/screen_dfs.R
+++ b/R/screen_dfs.R
@@ -12,18 +12,20 @@
 #' every test, if FALSE run silently
 #' @param stop_on_error logical, if TRUE will stop with an error if the result
 #' is "FAIL", and will throw genuine warning if result is "WARNING"
+#' @param prudence prudence as used by duckplyr, default = "lavish". Can also 
+#' be "stingy" and "thrifty".
 #'
 #' @inherit screen_filenames return
 #'
 #' @examples
 #' screen_dfs(example_data, example_meta)
 #' @export
-screen_dfs <- function(data, meta, verbose = FALSE, stop_on_error = FALSE) {
+screen_dfs <- function(data, meta, verbose = FALSE, stop_on_error = FALSE, prudence = "lavish") {
   validate_arg_dfs(data, meta)
   validate_arg_logical(verbose, "verbose")
   validate_arg_logical(stop_on_error, "stop_on_error")
 
-  data <- duckplyr::as_duckdb_tibble(data)
+  data <- duckplyr::as_duckdb_tibble(data, prudence = prudence)
 
   # Precheck columns ----------------------------------------------------------
   precheck_col_results <- rbind(

--- a/R/screen_dfs.R
+++ b/R/screen_dfs.R
@@ -12,7 +12,7 @@
 #' every test, if FALSE run silently
 #' @param stop_on_error logical, if TRUE will stop with an error if the result
 #' is "FAIL", and will throw genuine warning if result is "WARNING"
-#' @param prudence prudence as used by duckplyr, default = "lavish". Can also 
+#' @param prudence prudence as used by duckplyr, default = "lavish". Can also
 #' be "stingy" and "thrifty".
 #'
 #' @inherit screen_filenames return
@@ -20,7 +20,13 @@
 #' @examples
 #' screen_dfs(example_data, example_meta)
 #' @export
-screen_dfs <- function(data, meta, verbose = FALSE, stop_on_error = FALSE, prudence = "lavish") {
+screen_dfs <- function(
+  data,
+  meta,
+  verbose = FALSE,
+  stop_on_error = FALSE,
+  prudence = "lavish"
+) {
   validate_arg_dfs(data, meta)
   validate_arg_logical(verbose, "verbose")
   validate_arg_logical(stop_on_error, "stop_on_error")

--- a/man/screen_dfs.Rd
+++ b/man/screen_dfs.Rd
@@ -4,7 +4,13 @@
 \alias{screen_dfs}
 \title{Run all checks against data and metadata}
 \usage{
-screen_dfs(data, meta, verbose = FALSE, stop_on_error = FALSE)
+screen_dfs(
+  data,
+  meta,
+  verbose = FALSE,
+  stop_on_error = FALSE,
+  prudence = "lavish"
+)
 }
 \arguments{
 \item{data}{data.frame, for the data table, more efficient if supplied as a
@@ -17,6 +23,9 @@ every test, if FALSE run silently}
 
 \item{stop_on_error}{logical, if TRUE will stop with an error if the result
 is "FAIL", and will throw genuine warning if result is "WARNING"}
+
+\item{prudence}{prudence as used by duckplyr, default = "lavish". Can also
+be "stingy" and "thrifty".}
 }
 \value{
 data.frame containing the results of the screening


### PR DESCRIPTION
## Overview of changes

After some handy investigation, Dunc identified that `ncol()` materialises the whole of a lazy table unnecessarily. So this PR just replaces the use of `ncol()` in the meta rows count versus data columns count check. 

## Why are these changes being made?

This has a big impact on resource usage when screening large data files.

## Checklist

- [x] I have tested these changes locally using `shinytest2::test_app()`<!-- replace with your specific automated test command if different -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

I've also written some info into the contributor guidance on how Dunc identified the issue and added a corresponding flag to `screen_dfs()` to make running the debugging more reproducible. It's more of a developer mode thing, so not 100% sure this is the appropriate way to take it, but I do feel like it'd be useful when adding tests that there's an easy way for people to check the test that they're creating isn't _unnecessarily_ materialising the data frame. Some tests will need to do some level of materialisation, but maybe `"thrifty"` comes in useful as a threshold point in those cases to make sure they're not _too_ resource intensive.

For info, there's some useful background on prudence at https://duckplyr.tidyverse.org/articles/prudence.html
