### PR TITLE
Set read-in to fix all columns to VARCHAR type

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -187,14 +187,20 @@ read_ees_files <- function(datapath, metapath) {
   # Read in the CSV files -----------------------------------------------------
   # TODO: Add better handling for if there's issues reading the files
 
+  # Check number of columns in data file in order to be able to set them all as
+  # VARCHAR on the actual read in:
+  n_data_cols <- datapath |>
+    duckplyr::read_csv_duckdb(prudence = "thrifty") |>
+    dplyr::tbl_vars() |>
+    length()
+
   # Lazy reading of data for speed
-  datafile <- duckplyr::read_csv_duckdb(
-    datapath,
-    # Tried specifying indicator cols as VARCHAR but in current duckdb version
-    # ...you can only specify one at a time
-    # Resorting to scanning full file for types for now
-    options = list(sample_size = -1)
-  )
+  # Setting all columns to VARCHAR as everything can basically contain a
+  # character (i.e. indicators often contain x, c, z, etc)
+  datafile <- datapath |>
+    duckplyr::read_csv_duckdb(
+      options = list(types = list(rep("VARCHAR", n_data_cols)))
+    )
 
   # Issue with read.csv falling over when handed files from Azure, so using
   # ...duckplyr as a safer reading in method


### PR DESCRIPTION
## Overview of changes

The csv read in function is currently timing out the connection to the docker environment when run with large files on EES. This seems to be down to the step in which it loops through all rows to identify the column type. I've changed the code to bypass the column type scanning and just treat all columns as varchar type, which should make the read in stage a lot quicker with large files.

## Why are these changes being made?

Optimise run times on the platform and prevent timeouts on the connections.

## Checklist

- [x] I have tested these changes locally using `shinytest2::test_app()`<!-- replace with your specific automated test command if different -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

Would be helpful to run on Azure with a large file to check for hitting the time out limit.