### PR TITLE
add dockerfile and instructions

### DIFF
--- a/docker/Dockerfile-eesyscreener-dev
+++ b/docker/Dockerfile-eesyscreener-dev
@@ -21,6 +21,6 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# Install latest eesyscreener dependencies from DESCRIPTION
 COPY DESCRIPTION /tmp/DESCRIPTION
-RUN Rscript -e "deps <- tools::package_dependencies('/tmp/DESCRIPTION', db = available.packages(), which = c('Depends', 'Imports', 'LinkingTo', 'Suggests'), recursive = TRUE, fields = c('Depends', 'Imports', 'LinkingTo', 'Suggests')); pkgs <- unique(unlist(deps)); pkgs <- setdiff(pkgs, c('R', 'base')); install.packages(pkgs, repos = 'https://cloud.r-project.org')"
+
+RUN Rscript -e "install.packages(c('devtools', 'desc', 'pak')); desc::desc_get_deps(file = '/tmp/DESCRIPTION')[['package']] |> setdiff(c('R', 'base')) |> pak::pak()"

--- a/docker/Dockerfile-eesyscreener-dev
+++ b/docker/Dockerfile-eesyscreener-dev
@@ -1,0 +1,26 @@
+FROM r-base:latest
+
+RUN \
+  apt update && \
+  \
+  apt install -y \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    libfreetype6-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libpng-dev \
+    libcairo2-dev \
+    pkg-config \
+    libtiff5-dev \
+    libjpeg-dev \
+    libwebp-dev \
+    build-essential && \
+  \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install latest eesyscreener dependencies from DESCRIPTION
+COPY DESCRIPTION /tmp/DESCRIPTION
+RUN Rscript -e "deps <- tools::package_dependencies('/tmp/DESCRIPTION', db = available.packages(), which = c('Depends', 'Imports', 'LinkingTo', 'Suggests'), recursive = TRUE, fields = c('Depends', 'Imports', 'LinkingTo', 'Suggests')); pkgs <- unique(unlist(deps)); pkgs <- setdiff(pkgs, c('R', 'base')); install.packages(pkgs, repos = 'https://cloud.r-project.org')"

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,8 @@ If you're not a regular R user or don't want to set up R and all the dependencie
 
 These instructions assume you already have Docker installed. If you don't, please refer to the [Docker installation guide](https://docs.docker.com/get-docker/) for your operating system.
 
+A word of warning before you start, R packages can be notoriously slow to install and build on Linux, so the first time you build this image it might take a while...
+
 1. Open a terminal and go to the repository root.
 
 2. Build the image:
@@ -15,7 +17,7 @@ These instructions assume you already have Docker installed. If you don't, pleas
 3. Start a container:
 
 	```sh
-	docker run -ti --name eesyscreener-dev -v ".":"/home/r" -w /home/r eesyscreener-dev
+	docker run -ti --name eesyscreener-dev -v ".:/home/r" -w /home/r eesyscreener-dev
 	```
 
 4. In the R console, run:
@@ -24,17 +26,21 @@ These instructions assume you already have Docker installed. If you don't, pleas
 	devtools::load_all()
 	```
 
-5. Screen away! For example:
+5. Screen away in the R console! For example:
 
 	```r
-	screen_csv("sample-data/example.csv", "sample-data/example.meta.csv")
+	screen_dfs(example_data, example_meta) # use example data objects built into package
 	```
 
-	(Assuming you have example files in a `sample-data` folder at the repo root.)
+	```r
+	screen_csv("sample-data/example.csv", "sample-data/example.meta.csv") # use your own CSVs within a 'sample-data' folder in the repo root
+	```
 
+	Refer to the README and docs for more guidance on using the package, and use `quit()` to stop the R session.
 
-To restart the container at a later time:
+	To restart the container at a later time:
 
-```sh
-docker start eesyscreener-dev
-```
+	```sh
+	docker start eesyscreener-dev
+	```
+	

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,40 @@
+## Running eesyscreener in Docker
+
+If you're not a regular R user or don't want to set up R and all the dependencies on your machine, you can use Docker to run eesyscreener in a containerised R environment.
+
+These instructions assume you already have Docker installed. If you don't, please refer to the [Docker installation guide](https://docs.docker.com/get-docker/) for your operating system.
+
+1. Open a terminal and go to the repository root.
+
+2. Build the image:
+
+	```sh
+	docker build -f docker/Dockerfile-eesyscreener-dev -t eesyscreener-dev .
+	```
+
+3. Start a container:
+
+	```sh
+	docker run -ti --name eesyscreener-dev -v ".":"/home/r" -w /home/r eesyscreener-dev
+	```
+
+4. In the R console, run:
+
+	```r
+	devtools::load_all()
+	```
+
+5. Screen away! For example:
+
+	```r
+	screen_csv("sample-data/example.csv", "sample-data/example.meta.csv")
+	```
+
+	(Assuming you have example files in a `sample-data` folder at the repo root.)
+
+
+To restart the container at a later time:
+
+```sh
+docker start eesyscreener-dev
+```


### PR DESCRIPTION
## Overview of changes

Following @duncan-at-hiveit's suggestion I've added a Dockerfile for running this package without needing to have R already installed.

I made one slight change, to pull in the dependencies from the DESCRIPTION file automatically, so we don't need to update this Dockerfile each time we add a dependency to the package itself (or more likely, we can't forget to do that and then confuse someone who's running the dockerfile and getting unusual R messages because dependencies are missing!).

Fixes #18 

## Why are these changes being made?

We expect EES developers may want to test or use the package themselves locally, and most of those are not regular R users.

## Checklist

- [x] I have tested these changes locally using `devtools::check()`
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

I don't have Docker on my work laptop so can't test this myself currently, so suggesting you give this a review to see if it does what I'm hoping / you were looking for @duncan-at-hiveit!