### PR TITLE
Precompiled binar-EES!

### DIFF
--- a/docker/Dockerfile-eesyscreener-dev
+++ b/docker/Dockerfile-eesyscreener-dev
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM rocker/r-ver:4.5.2
 
 RUN \
   apt update && \
@@ -23,4 +23,8 @@ RUN \
 
 COPY DESCRIPTION /tmp/DESCRIPTION
 
-RUN Rscript -e "install.packages(c('devtools', 'desc', 'pak')); desc::desc_get_deps(file = '/tmp/DESCRIPTION')[['package']] |> setdiff(c('R', 'base')) |> pak::pak()"
+# Install R packages using pre-complied binaries for Ubuntu Noble
+RUN R -e "options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/noble/latest')); \
+          install.packages('pak'); \
+          pak::pak(c('devtools', 'desc')); \
+          desc::desc_get_deps(file = '/tmp/DESCRIPTION')[['package']] |> setdiff(c('R', 'base')) |> pak::pak()"

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,6 @@ If you're not a regular R user or don't want to set up R and all the dependencie
 
 These instructions assume you already have Docker installed. If you don't, please refer to the [Docker installation guide](https://docs.docker.com/get-docker/) for your operating system.
 
-A word of warning before you start, R packages can be notoriously slow to install and build on Linux, so the first time you build this image it might take a while...
-
 1. Open a terminal and go to the repository root.
 
 2. Build the image:


### PR DESCRIPTION
## Overview of changes

Following on from , and using what I now know from https://github.com/dfe-analytical-services/ees-screener-api/pull/16, I have managed to figure out how to speed up the docker image and remove the warning!

## Why are these changes being made?

It was taking around 45-50 mins to build the image before, entirely due to the R packages being installed from source, now that part of the process is about 90 seconds 🚤 

## Checklist

- [x] I have tested these changes locally<!-- replace with your specific automated test command if different -->
- [x] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Just check you can still follow the instructions and that it's as quick for you as it is for me.