### PR TITLE
Adding ability for filter default check to handle NAs in the meta column

### DIFF
--- a/R/check_filter_defaults.R
+++ b/R/check_filter_defaults.R
@@ -36,6 +36,7 @@ check_filter_defaults <- function(
       dplyr::mutate(
         filter_default = dplyr::case_when(
           .data$filter_default == "" & col_type == "Filter" ~ "Total",
+          is.na(.data$filter_default) & col_type == "Filter" ~ "Total",
           .default = .data$filter_default
         )
       )
@@ -84,6 +85,7 @@ check_filter_defaults <- function(
         any(dfilters[[column]] == filter_defaults[[column]])
       }
     )
+
     if (all(pre_result)) {
       return(
         test_output(

--- a/tests/testthat/test-check_filter_defaults.R
+++ b/tests/testthat/test-check_filter_defaults.R
@@ -9,6 +9,17 @@ test_that("check_filter_defaults gives WARNING correctly when no totals or filte
   )
 })
 
+test_that("check_filter_defaults gives WARNING correctly when read-in meta has NAs under filter defaults", {
+  expect_equal(
+    check_filter_defaults(
+      example_data,
+      example_meta |>
+        dplyr::mutate(filter_default = "")
+    )$result,
+    "WARNING"
+  )
+})
+
 test_that("check_filter_defaults gives a pass when no filters are present", {
   expect_equal(
     check_filter_defaults(


### PR DESCRIPTION
## Overview of changes

Some files were failing at the filter default check due to the meta read-in setting blank cells to NAs rather than empty strings as the code expected.

I've taken the simplest brute force approach and just adapted the check itself to be able to handle either NA or "". 

I did weigh up either adapting the `read_ees_files()` function to set all NAs in the meta to empty strings or doing something similar elsewhere centrally, but took the more direct option of just adapting the function itself. This was largely just down to just implementing a fix in the same place the bug was happening in the first place, but thinking about it afterwards, by doing it this way, it makes the individual test more robust if someone wants to run it in isolation in a pipeline. Another alternative might be to force a standard centrally on the read in and then add some clear validation on the function itself for anyone running it in isolation. Not sure if that's better practice or just over-engineering to be honest.

## Why are these changes being made?

To prevent the screener falling over when reading in filter_default entries.

## Checklist

- [x] I have tested these changes locally using automated tests <!-- replace with your specific automated test command e.g. `shinytest2::test_app()` -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

