### PR TITLE
Adding dd_check=FALSE option to exclude data dictionary checks

### DIFF
--- a/R/screen_csv.R
+++ b/R/screen_csv.R
@@ -53,6 +53,7 @@ screen_csv <- function(
   metafilename = NULL,
   log_key = NULL,
   log_dir = "./",
+  dd_checks = TRUE,
   verbose = FALSE,
   stop_on_error = FALSE
 ) {
@@ -149,6 +150,7 @@ screen_csv <- function(
     metafile,
     log_key = log_key,
     log_dir = log_dir,
+    dd_checks = dd_checks,
     verbose = verbose,
     stop_on_error = stop_on_error
   )

--- a/R/screen_dfs.R
+++ b/R/screen_dfs.R
@@ -11,6 +11,8 @@
 #' @param log_key keystring for creating log file. If given, the screening will
 #' write a log file to disk called eesyscreening_log_<log_key>.json default=NULL
 #' @param log_dir Directory within which to place the log file. default="./"
+#' @param dd_checks Run the Data dictionary tests, default=TRUE (this is implemented to allow devs
+#' to update robot test data to be consistent with data dictionary tests).
 #' @param verbose logical, if TRUE prints feedback messages to console for
 #' every test, if FALSE run silently
 #' @param stop_on_error logical, if TRUE will stop with an error if the result
@@ -28,6 +30,7 @@ screen_dfs <- function(
   meta,
   log_key = NULL,
   log_dir = "./",
+  dd_checks = TRUE,
   verbose = FALSE,
   stop_on_error = FALSE,
   prudence = "lavish"
@@ -329,14 +332,19 @@ screen_dfs <- function(
       "column-name",
       verbose = verbose,
       stop_on_error = stop_on_error
-    ),
-    check_api_dict_col_names(
-      meta,
-      verbose = verbose,
-      stop_on_error = stop_on_error
     )
-    # TODO: Add extra variations here
   )
+
+  if (dd_checks) {
+    check_api_results <- rbind(
+      check_api_results,
+      check_api_dict_col_names(
+        meta,
+        verbose = verbose,
+        stop_on_error = stop_on_error
+      )
+    )
+  }
 
   check_api_results <- check_api_results |>
     cbind("stage" = "Check API")

--- a/man/screen_csv.Rd
+++ b/man/screen_csv.Rd
@@ -11,6 +11,7 @@ screen_csv(
   metafilename = NULL,
   log_key = NULL,
   log_dir = "./",
+  dd_checks = TRUE,
   verbose = FALSE,
   stop_on_error = FALSE
 )
@@ -30,6 +31,9 @@ it will be assumed from the path}
 write a log file to disk called eesyscreening_log_<log_key>.json default=NULL}
 
 \item{log_dir}{Directory within which to place the log file. default="./"}
+
+\item{dd_checks}{Run the Data dictionary tests, default=TRUE (this is implemented to allow devs
+to update robot test data to be consistent with data dictionary tests).}
 
 \item{verbose}{logical, if TRUE prints feedback messages to console for
 every test, if FALSE run silently}

--- a/man/screen_dfs.Rd
+++ b/man/screen_dfs.Rd
@@ -9,6 +9,7 @@ screen_dfs(
   meta,
   log_key = NULL,
   log_dir = "./",
+  dd_checks = TRUE,
   verbose = FALSE,
   stop_on_error = FALSE,
   prudence = "lavish"
@@ -24,6 +25,9 @@ lazy duckplyr data.frame}
 write a log file to disk called eesyscreening_log_<log_key>.json default=NULL}
 
 \item{log_dir}{Directory within which to place the log file. default="./"}
+
+\item{dd_checks}{Run the Data dictionary tests, default=TRUE (this is implemented to allow devs
+to update robot test data to be consistent with data dictionary tests).}
 
 \item{verbose}{logical, if TRUE prints feedback messages to console for
 every test, if FALSE run silently}


### PR DESCRIPTION
## Overview of changes

Sadly the EES public API robot test data is largely inconsistent with the data dictionary as it was created prior to us harmonising the data sets and creating the dictionary. It's going to take some effort to bring the tests completely inline with the data dictionary, so in the meantime I'm adding a parameter to allow robot test runs to turn off the data dictionary tests.

## Why are these changes being made?

To allow EES robot tests to work.

## Checklist

<!-- Customise this checklist based on expectations for your repository -->

- [x] I have tested these changes locally using automated tests <!-- replace with your specific automated test command e.g. `shinytest2::test_app()` -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

<!-- Put any specific questions or instructions for reviewers in here -->
