### PR TITLE
Bugfix/filter blanks add nas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: eesyscreener
 Title: Explore education statistics data screening
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Cam", "Race", , "cameron.race@education.gov.uk", role = c("aut", "cre")),
     person("Rich", "Bielby", , "richard.bielby@education.gov.uk", role = "aut",

--- a/R/check_filter_blanks.R
+++ b/R/check_filter_blanks.R
@@ -24,7 +24,6 @@ check_filter_blanks <- function(
   test_name <- get_check_name()
 
   filter_cols <- get_filters(meta, include_filter_groups = TRUE) |> unique()
-
   if (length(filter_cols) == 0) {
     return(test_output(
       test_name,
@@ -35,14 +34,22 @@ check_filter_blanks <- function(
     ))
   }
 
+  if (verbose){message("Filters found: ", paste(filter_cols, collapse = ","))}
   # Single query across all filter columns. Filter columns are always character
   # so no type-mismatch risk with the empty-string literal.
   result_row <- data |>
+    dplyr::select(dplyr::all_of(filter_cols)) |>
+    dplyr::mutate(across(everything(), ~ dplyr::if_else(is.na(.), "", .))) |>
     dplyr::summarise(dplyr::across(
       dplyr::all_of(filter_cols),
       ~ sum(. == "") > 0
     )) |>
     dplyr::collect()
+  if (verbose){
+    message(
+      paste0(names(result_row), ": ", result_row,  collapse = ", ")
+    )
+  }
 
   cols_with_blanks <- names(result_row)[unlist(result_row, use.names = FALSE)]
 

--- a/R/check_filter_blanks.R
+++ b/R/check_filter_blanks.R
@@ -34,7 +34,9 @@ check_filter_blanks <- function(
     ))
   }
 
-  if (verbose){message("Filters found: ", paste(filter_cols, collapse = ","))}
+  if (verbose) {
+    message("Filters found: ", paste(filter_cols, collapse = ","))
+  }
   # Single query across all filter columns. Filter columns are always character
   # so no type-mismatch risk with the empty-string literal.
   result_row <- data |>
@@ -45,9 +47,9 @@ check_filter_blanks <- function(
       ~ sum(. == "") > 0
     )) |>
     dplyr::collect()
-  if (verbose){
+  if (verbose) {
     message(
-      paste0(names(result_row), ": ", result_row,  collapse = ", ")
+      paste0(names(result_row), ": ", result_row, collapse = ", ")
     )
   }
 


### PR DESCRIPTION
## Overview of changes

The filter blanks check was throwing an ambiguous error message for a robot test file where blanks were present. Blanks were passed as NAs, which led to the check fail message showing NA as the column name. I've adapted the check to replace NAs with actual blanks and then it properly reports the column name containing those.

## Why are these changes being made?

Clear check fail messages required.

## Checklist

<!-- Customise this checklist based on expectations for your repository -->

- [x] I have tested these changes locally using automated tests <!-- replace with your specific automated test command e.g. `shinytest2::test_app()` -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

I've also added a bit of extra verbosity on the check to help with debugging.
